### PR TITLE
Add legal footer links

### DIFF
--- a/webapp/app/layout.tsx
+++ b/webapp/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import Footer from '@/components/footer'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -14,7 +15,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className="min-h-screen flex flex-col">
+        <div className="flex-grow">{children}</div>
+        <Footer />
+      </body>
     </html>
   )
 }

--- a/webapp/components/footer.tsx
+++ b/webapp/components/footer.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+export default function Footer() {
+  return (
+    <footer className="bg-white/80 backdrop-blur-sm border-t border-pink-200 py-4">
+      <div className="container mx-auto px-4 text-center text-sm text-slate-600">
+        <Link
+          href="https://paulsundays.com/terms-and-conditions.pdf"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-pink-600 mr-4"
+        >
+          Términos y Condiciones
+        </Link>
+        <Link
+          href="https://paulsundays.com/privacy-policy.pdf"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-pink-600"
+        >
+          Política de Privacidad
+        </Link>
+      </div>
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple footer with links to terms and privacy policy
- render the new footer in the root layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685709ef627c8330b5ea92ef9ecf5207